### PR TITLE
Exclude questionset questions

### DIFF
--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -61,10 +61,10 @@ Route::group(['prefix' => 'api', 'middleware' => 'jwt.auth'], function () {
         Route::post('/questions', 'QuestionController@create');
 
         // QuestionSet Routes
-        Route::get('/question-sets', 'QuestionSetController@index');
-        Route::get('/question-sets/{id}', 'QuestionSetController@show');
-        Route::post('/question-sets', 'QuestionSetController@create');
-        Route::post('/question-sets/{id}/questions', 'QuestionSetController@addQuestions');
+        Route::get('/question_sets', 'QuestionSetController@index');
+        Route::get('/question_sets/{id}', 'QuestionSetController@show');
+        Route::post('/question_sets', 'QuestionSetController@create');
+        Route::post('/question_sets/{id}/questions', 'QuestionSetController@addQuestions');
 
         // School Routes
         Route::get('/schools', 'SchoolController@index');
@@ -76,7 +76,7 @@ Route::group(['prefix' => 'api', 'middleware' => 'jwt.auth'], function () {
         Route::get('/semesters', 'SemesterController@index');
         Route::post('/semesters', 'SemesterController@create');
         Route::put('/semesters/{id}', 'SemesterController@update');
-        Route::post('/semesters/{id}/question-sets', 'SemesterController@addQuestionSet');
-        Route::put('/semesters/{id}/question-sets/{questionSetId}', 'SemesterController@updateQuestionSetStatus');
     });
+        Route::post('/semesters/{id}/question_sets', 'SemesterController@addQuestionSet');
+        Route::put('/semesters/{id}/question_sets/{questionSetId}', 'SemesterController@updateQuestionSetStatus');
 });

--- a/app/Repositories/Database/EloquentQuestionSetRepository.php
+++ b/app/Repositories/Database/EloquentQuestionSetRepository.php
@@ -10,7 +10,6 @@ use Fce\Models\QuestionSet;
 use Fce\Repositories\Contracts\QuestionSetRepository;
 use Fce\Repositories\Repository;
 use Fce\Transformers\QuestionSetTransformer;
-use Illuminate\Support\Facades\Input;
 
 class EloquentQuestionSetRepository extends Repository implements QuestionSetRepository
 {
@@ -24,10 +23,6 @@ class EloquentQuestionSetRepository extends Repository implements QuestionSetRep
     {
         $this->model = $model;
         $this->transformer = $transformer;
-
-        //This is used to ensure questions are always included when question sets are retrieved
-        //It serves as a replacement to defaultIncludes
-        Input::merge(['include' => 'questions']);
     }
 
     /**

--- a/app/Repositories/Database/EloquentSemesterRepository.php
+++ b/app/Repositories/Database/EloquentSemesterRepository.php
@@ -13,6 +13,7 @@ use Fce\Repositories\Repository;
 use Fce\Transformers\QuestionSetTransformer;
 use Fce\Transformers\SemesterTransformer;
 use Fce\Utility\Status;
+use Illuminate\Support\Facades\Input;
 
 class EloquentSemesterRepository extends Repository implements SemesterRepository
 {
@@ -26,6 +27,9 @@ class EloquentSemesterRepository extends Repository implements SemesterRepositor
     {
         $this->model = $model;
         $this->transformer = $transformer;
+
+        // Exclude a question set's nested questions.
+        Input::merge(['exclude' => 'questionSets.questions']);
     }
 
     /**

--- a/app/Transformers/QuestionSetTransformer.php
+++ b/app/Transformers/QuestionSetTransformer.php
@@ -15,7 +15,7 @@ class QuestionSetTransformer extends TransformerAbstract
     /**
      * @var array
      */
-    protected $availableIncludes = [
+    protected $defaultIncludes = [
         'questions',
     ];
 

--- a/app/Utility/Transformable.php
+++ b/app/Utility/Transformable.php
@@ -31,9 +31,14 @@ trait Transformable
     {
         $fractalManager = new FractalManager();
         $includes = Input::get('include');
+        $excludes = Input::get('exclude');
 
         if ($includes) {
             $fractalManager = $fractalManager->parseIncludes($includes);
+        }
+
+        if ($excludes) {
+            $fractalManager = $fractalManager->parseExcludes($excludes);
         }
 
         return new Fractal($fractalManager);

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": ">=5.5.9",
         "laravel/framework": "5.2.*",
-        "league/fractal": "^0.13.0",
+        "league/fractal": "dev-master",
         "tymon/jwt-auth": "dev-develop"
     },
     "require-dev": {


### PR DESCRIPTION
Cleaner library supported way of excluding questions when getting a semester's question sets. 

Also noticed the hypenated `question-sets` route were not working when testing. Had to switch to underscores `question_sets`.